### PR TITLE
sound: wcd9335:  Disable modes which break earpiece

### DIFF
--- a/sound/soc/codecs/wcd9335.c
+++ b/sound/soc/codecs/wcd9335.c
@@ -186,12 +186,12 @@ enum tasha_sido_voltage {
 int sound_control_spk_priv = 0;
 int sound_control_spk_gain = 0;
 
-static int huwifi_mode = 1;
+static int huwifi_mode = 0;
 module_param(huwifi_mode, int,
 	S_IRUGO | S_IWUSR | S_IWGRP);
 MODULE_PARM_DESC(huwifi_mode, "enable/disable l UHQA Mode");
 
-static int low_distort_amp = 1;
+static int low_distort_amp = 0;
 module_param(low_distort_amp, int,
 	S_IRUGO | S_IWUSR | S_IWGRP);
 MODULE_PARM_DESC(low_distort_amp, "enable/disable l Class AB Mode");


### PR DESCRIPTION
These break in-call earpiece audio on a handful of devices, and unfortunately, kenzo
is one. A workaround is to find a way to detect incoming calls and disable it then.
Signed-off-by: Laster K. <officiallazerl0rd@gmail.com>